### PR TITLE
ci: publish-on-release NPM_TOKEN auth fix (SAA-140)

### DIFF
--- a/.github/workflows/publish-on-release.yaml
+++ b/.github/workflows/publish-on-release.yaml
@@ -52,4 +52,8 @@ jobs:
       - run: npm run test:all
       - run: npm publish --access public
         env:
+          # The repo ships a committed .npmrc that reads ${NPM_TOKEN}, so this
+          # env name must match it. NODE_AUTH_TOKEN also satisfies the user-level
+          # .npmrc that setup-node generates from `registry-url`.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Sets NPM_TOKEN env on the publish step to match the committed .npmrc (`_authToken=${NPM_TOKEN}`). Triggers a release cycle to validate the full build=>test=>release=>publish chain end-to-end.