### PR TITLE
ci: cancel superseded trivy runs off-master (SAA-140)

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -16,6 +16,11 @@ on:
     # Weekly dependency-update pass (Monday 02:00 UTC).
     - cron: "0 2 * * 1"
 
+# Cancel superseded in-flight runs; never cancel runs on master.
+concurrency:
+  group: trivy-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   vuln:
     name: Trivy vuln scan


### PR DESCRIPTION
Adds a concurrency group to trivy-scan so superseded in-flight runs on PR branches are cancelled; master runs are never cancelled. Triggers a release cycle to validate the full automatic release=>publish chain (release authored by GH_TOKEN PAT -> publish-on-release auto-fires).