### PR TITLE
ci: release-on-tag token input fix (SAA-140)

### DIFF
--- a/.github/workflows/release-on-tag.yaml
+++ b/.github/workflows/release-on-tag.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          github_token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
           files: |
             Release.txt
             README.md


### PR DESCRIPTION
softprops/action-gh-release@v2 uses the `token` input (not `github_token`). Fixing so the release is authored by the GH_TOKEN PAT and publish-on-release auto-fires on the `release` event.