### PR TITLE
ci/test: reporter temp dirs pre-created; pages deploys on release tags

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,5 +1,8 @@
 name: "Pages Builder"
 
+# Docs deploy exactly once per release: every merge to master produces a
+# release (release-on-merge-pr), whose tag push triggers this deployment.
+# Plain branch pushes deliberately do not deploy.
 # Thin caller of decaf-ts/reusable-actions/.github/workflows/pages.yaml.
 
 on:
@@ -7,10 +10,6 @@ on:
   push:
     tags:
       - 'v?[0-9]+.[0-9]+.[0-9]+'
-    branches: [ master, main ]
-    paths:
-      - workdocs/**
-      - .github/workflows/pages.yaml
 
 jobs:
   deploy:

--- a/tests/unit/ts-workspace.test.ts
+++ b/tests/unit/ts-workspace.test.ts
@@ -1,5 +1,6 @@
 import type { WorkspaceModule } from "../workspace-target";
 import { loadWorkspaceModule } from "../workspace-target";
+import { mkdirSync } from "fs";
 
 interface AddAttachParams {
   attach: string | Buffer;
@@ -32,9 +33,18 @@ let workspaceModule: WorkspaceModule;
 async function importHelpers(): Promise<void> {
   // if (!process.env[JestReportersTempPathEnvKey])
   //   process.env[JestReportersTempPathEnvKey] = './workdocs/reports';
-  const { addMsg, addAttach } = await normalizeImport(
+  const { addMsg, addAttach, dataDirPath, attachDirPath } = await normalizeImport(
     import("jest-html-reporters/helper")
   );
+  // The temp dirs are created by the jest-html-reporters REPORTER at the start
+  // of a run and cleaned after its data is merged into the html report. Jest
+  // re-runs WITHOUT the reporter configured (e.g. the coverage-report action's
+  // annotation pass) therefore have no dirs, and the helper's writeJSON fails
+  // with ENOENT since it does not create parent directories. Create them first
+  // so messages/attachments are always accepted; a reporter active in the same
+  // run will pick them up and merge them into the report.
+  mkdirSync(dataDirPath, { recursive: true });
+  mkdirSync(attachDirPath, { recursive: true });
   addMsgFunction = addMsg;
   addAttachFunction = addAttach;
 }


### PR DESCRIPTION
## What

- **test**: pre-create the jest-html-reporters temp dirs (data/images) before using the helper. The helper's writeJSON cannot create parent dirs; the dirs are normally created by the reporter, which is absent in the coverage-report action's annotation re-run — that re-run crashed with ENOENT and failed the 'Tests annotations' check. Verified locally: with the temp dir deleted and no reporter configured, the suite passes and the message/attachment JSONs land in data/.
- **pages**: deploy docs exactly once per release (tag push). Plain branch pushes no longer deploy; every merge produces a release, so every merge still yields exactly one deployment.

## Expected post-merge invocations (v3.10.24)

- release-on-merge-pr (bump + tag) — 1
- release-on-tag: trivy gate + snyk gate -> Release — 1
- publish-on-release (npm) — 1
- pages deploy — 1 (tag push)
- codeql — 1 (tag push)
- standalone snyk/trivy — 0