### PR TITLE
ci: jest config is the sole coverage gate

### DIFF
--- a/.github/workflows/jest-coverage.yaml
+++ b/.github/workflows/jest-coverage.yaml
@@ -14,5 +14,4 @@ jobs:
     with:
       # template repo ships a minimal src/ sample; keep the threshold under its
       # current 77% statement coverage until the sample is broadened
-      coverage-threshold: 75
     secrets: inherit

--- a/.github/workflows/jest-coverage.yaml
+++ b/.github/workflows/jest-coverage.yaml
@@ -11,7 +11,4 @@ on:
 jobs:
   coverage:
     uses: decaf-ts/reusable-actions/.github/workflows/jest-coverage.yaml@master
-    with:
-      # template repo ships a minimal src/ sample; keep the threshold under its
-      # current 77% statement coverage until the sample is broadened
     secrets: inherit

--- a/workdocs/reports/jest.coverage.config.cjs
+++ b/workdocs/reports/jest.coverage.config.cjs
@@ -32,7 +32,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 60,
-      functions: 80,
+      functions: 81,
       lines: 79,
       statements: 77,
     },


### PR DESCRIPTION
Cleanup follow-up to the reusable-actions adoption:

- the reusable `jest-coverage.yaml` no longer accepts a `coverage-threshold` input - coverage is enforced exclusively by jest's `coverageThreshold` in `workdocs/reports/jest.coverage.config.cjs` via `npm run coverage` (artiomtr PR report is report-only)
- this repo's jest coverage limits are updated to the currently measured coverage (from the latest CI coverage run)
